### PR TITLE
[Bugfix] Fix allocation month info in payment list

### DIFF
--- a/src/routes/family/components/payments-list.tsx
+++ b/src/routes/family/components/payments-list.tsx
@@ -64,6 +64,7 @@ export function FamilyPaymentsList({ payments }: FamilyPaymentsListProps) {
                 {new Date(payment.month).toLocaleDateString(lang, {
                   year: 'numeric',
                   month: 'short',
+                  timeZone: 'UTC',
                 })}
               </div>
             </div>


### PR DESCRIPTION
Payment list allocation month was always showing the previous month instead of the actual month it was from