### PR TITLE
Fix vite manualChunks broken by Rollup 4.59 bump

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,33 +19,14 @@ export default defineConfig({
         entryFileNames: 'assets/[name].[hash].js',
         chunkFileNames: 'assets/[name].[hash].js',
         assetFileNames: 'assets/[name].[hash].[ext]',
-        manualChunks: {
-          // Split large vendor chunks
-          'react-vendor': ['react', 'react-dom'],
-          'clerk-vendor': [
-            '@clerk/clerk-react',
-            '@clerk/localizations',
-            '@clerk/types',
-          ],
-          'radix-vendor': [
-            '@radix-ui/react-avatar',
-            '@radix-ui/react-checkbox',
-            '@radix-ui/react-dialog',
-            '@radix-ui/react-dropdown-menu',
-            '@radix-ui/react-label',
-            '@radix-ui/react-navigation-menu',
-            '@radix-ui/react-popover',
-            '@radix-ui/react-radio-group',
-            '@radix-ui/react-select',
-            '@radix-ui/react-separator',
-            '@radix-ui/react-slot',
-          ],
-          'tanstack-vendor': [
-            '@tanstack/react-query',
-            '@tanstack/react-router',
-            '@tanstack/router-devtools',
-          ],
-          'sentry-vendor': ['@sentry/react', '@sentry/tracing'],
+        manualChunks: (id) => {
+          if (!id.includes('node_modules')) return
+          if (/node_modules\/(react|react-dom|scheduler)\//.test(id))
+            return 'react-vendor'
+          if (id.includes('@clerk/')) return 'clerk-vendor'
+          if (id.includes('@radix-ui/')) return 'radix-vendor'
+          if (id.includes('@tanstack/')) return 'tanstack-vendor'
+          if (id.includes('@sentry/')) return 'sentry-vendor'
         },
       },
     },


### PR DESCRIPTION
## Summary
- Convert \`manualChunks\` in \`vite.config.ts\` from static-object form to function form
- Resolves \"Cannot read properties of undefined (reading 'Component')\" runtime error on staging

## Why
PR #199 bumped rollup 4.46.2 → 4.59.0 transitively via the npm_and_yarn dependabot group. Rollup 4.59 changed its chunking heuristics, and the existing static-object \`manualChunks\` config started producing:

- \`Generated an empty chunk: \"react-vendor\"\`
- 3× \`Circular chunk: tanstack-vendor ↔ radix-vendor ↔ clerk-vendor\` warnings

The empty react-vendor chunk meant \`tanstack-vendor\` imported React from a hollow module → \`undefined.Component\` at runtime.

The function form does precise path matching, which catches react's scheduler internals and the full \`@clerk/*\` and \`@sentry/*\` package families (not just the named entry packages).

## Verification
Build output on this branch (origin/dev + this fix):
- ✅ No empty chunk warnings
- ✅ No circular chunk warnings
- \`react-vendor.*.js\`: 0.05 kB → 193 kB (real React+ReactDOM+scheduler)

## Test plan
- [ ] Deploy to staging
- [ ] Hard reload, verify app loads without console errors
- [ ] DevTools → Network: confirm \`react-vendor.*.js\` is ~190 kB (not empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)